### PR TITLE
feat!: return Result from cuckoo_filter delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ pub fn main() {
   let in_filter = cuckoo_filter.might_contain(filter, "hello")  // True
   let not_in_filter = cuckoo_filter.might_contain(filter, "goodbye")  // False
 
-  // Remove one previously inserted copy of an item
-  let filter = cuckoo_filter.delete(filter, "hello")
+  // Remove one previously inserted copy of an item. Deleting an item whose
+  // fingerprint is absent fails with ItemNotPresent, so it returns a Result.
+  let assert Ok(filter) = cuckoo_filter.delete(filter, "hello")
   let gone = cuckoo_filter.might_contain(filter, "hello")  // False
 
   // Get filter properties
@@ -159,7 +160,7 @@ pub fn main() {
 }
 ```
 
-> **Only delete items you have actually inserted.** A Cuckoo filter matches on fingerprints, so deleting an item that was never inserted but happens to be a false positive drops *another* item's fingerprint — and that item then reads as missing, which is the one thing these filters otherwise rule out.
+> **Only delete items you have actually inserted.** A Cuckoo filter matches on fingerprints, so deleting an item that was never inserted but happens to be a false positive drops *another* item's fingerprint — and that item then reads as missing, which is the one thing these filters otherwise rule out. `delete` fails with `ItemNotPresent` when the fingerprint is wholly absent (a double delete or wrong key), but that check cannot catch the false-positive case: an `Ok` means a matching fingerprint was cleared, not that you deleted your own item.
 
 Further documentation can be found at <https://hexdocs.pm/gauzy>.
 
@@ -180,6 +181,9 @@ All creation operations return a `Result`. Each filter has its own error type �
 
 `cuckoo_filter.insert` and `cuckoo_filter.insert_many` also return a `Result`:
 - `FilterFull` —  No room could be made for the item. The filter is returned to you unchanged.
+
+`cuckoo_filter.delete` also returns a `Result`:
+- `ItemNotPresent` —  No slot held the item's fingerprint, so the filter does not contain it.
 
 Check/handle errors using Gleam’s `Result` type.
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gauzy"
-version = "2.0.4"
+version = "3.0.0"
 
 description = "gauzy is a Gleam library providing flexible implementations of probabilistic data structures"
 licences = ["Apache-2.0"]

--- a/src/gauzy/bloom_filter.gleam
+++ b/src/gauzy/bloom_filter.gleam
@@ -29,7 +29,8 @@ import iv.{type Array}
 /// would pack more densely on Erlang but silently lose low bits on JS.
 const word_size = 52
 
-/// Represents errors that can occur during Bloom filter operations.
+/// The failures that building a `BloomFilter` (or its hash-function pair) and
+/// estimating its cardinality can return.
 pub type BloomFilterError {
   /// The provided hash functions are equal, which is not allowed.
   EqualHashFunctions

--- a/src/gauzy/cuckoo_filter.gleam
+++ b/src/gauzy/cuckoo_filter.gleam
@@ -69,6 +69,13 @@ pub type CuckooFilterError {
   InvalidTargetErrorRate
   /// The filter could not house the item after `max_kicks` relocations.
   FilterFull
+  /// A `delete` found no slot holding the item's fingerprint in either
+  /// candidate bucket, so the filter does not contain it.
+  ///
+  /// Because membership is matched by fingerprint, this is the *only* thing
+  /// `delete` can detect: a *missing* fingerprint is certain, but a *matching*
+  /// one is not proof you deleted your own item — see `delete`.
+  ItemNotPresent
 }
 
 /// A pair of hash functions used by the Cuckoo filter.
@@ -235,8 +242,10 @@ pub fn might_contain(in filter: CuckooFilter(a), search item: a) -> Bool {
   find_item_slot(filter, item) |> result.is_ok
 }
 
-/// Removes one previously inserted copy of `item` from the `CuckooFilter`.
-/// Removing an item the filter does not hold leaves it unchanged.
+/// Removes one previously inserted copy of `item` from the `CuckooFilter`,
+/// returning the updated filter. Fails with `ItemNotPresent` when `item`'s
+/// fingerprint is absent from both its candidate buckets, i.e. the filter does
+/// not hold it.
 ///
 /// Only ever delete items you have actually inserted! A filter reports
 /// membership by fingerprint, so deleting a never-inserted item that happens to
@@ -244,17 +253,29 @@ pub fn might_contain(in filter: CuckooFilter(a), search item: a) -> Bool {
 /// reported as missing – the false negatives a Cuckoo filter otherwise rules
 /// out.
 ///
+/// `Ok` therefore means "a matching fingerprint was cleared", not "you deleted
+/// your own item": the false-positive case above still returns `Ok` while
+/// corrupting the filter, because it is indistinguishable from a real hit. The
+/// `ItemNotPresent` error only catches deletes of an item whose fingerprint is
+/// wholly absent – a double delete or a wrong key. It is a misuse check, not a
+/// guarantee.
+///
 /// * `filter`: The `CuckooFilter` to remove from
 /// * `item`: The item to remove
-pub fn delete(from filter: CuckooFilter(a), delete item: a) -> CuckooFilter(a) {
+pub fn delete(
+  from filter: CuckooFilter(a),
+  delete item: a,
+) -> Result(CuckooFilter(a), CuckooFilterError) {
   case find_item_slot(filter, item) {
     Ok(slot) ->
-      CuckooFilter(
-        ..filter,
-        array: write_slot(in: filter, at: slot, fingerprint: empty_slot),
-        item_count: filter.item_count - 1,
+      Ok(
+        CuckooFilter(
+          ..filter,
+          array: write_slot(in: filter, at: slot, fingerprint: empty_slot),
+          item_count: filter.item_count - 1,
+        ),
       )
-    Error(Nil) -> filter
+    Error(Nil) -> Error(ItemNotPresent)
   }
 }
 

--- a/test/gauzy/cuckoo_filter_test.gleam
+++ b/test/gauzy/cuckoo_filter_test.gleam
@@ -177,7 +177,9 @@ pub fn delete_works_test() -> Nil {
 
   let filter =
     int.range(from: 0, to: deleted, with: filter, run: fn(filter, element) {
-      cuckoo_filter.delete(filter, int.to_string(element))
+      let assert Ok(filter) =
+        cuckoo_filter.delete(filter, int.to_string(element))
+      filter
     })
 
   assert cuckoo_filter.item_count(filter) == inserted - deleted
@@ -197,12 +199,15 @@ pub fn delete_works_test() -> Nil {
   assert count_items_present(in: filter, with: deleted) <= 5
 }
 
-pub fn delete_missing_item_is_a_no_op_test() -> Nil {
+pub fn delete_missing_item_errors_test() -> Nil {
   let filter = create_test_filter(100, 0.01)
   let filter = insert_items(in: filter, with: 10)
 
-  let filter = cuckoo_filter.delete(filter, "never inserted")
+  // The item's fingerprint is absent, so the delete is rejected outright.
+  assert cuckoo_filter.delete(filter, "never inserted")
+    == Error(cuckoo_filter.ItemNotPresent)
 
+  // ...and the filter is left untouched.
   assert cuckoo_filter.item_count(filter) == 10
   assert all_items_present(in: filter, with: 10)
 }
@@ -213,11 +218,11 @@ pub fn delete_removes_one_copy_at_a_time_test() -> Nil {
   let assert Ok(filter) = cuckoo_filter.insert(filter, "twice")
   assert cuckoo_filter.item_count(filter) == 2
 
-  let filter = cuckoo_filter.delete(filter, "twice")
+  let assert Ok(filter) = cuckoo_filter.delete(filter, "twice")
   assert cuckoo_filter.item_count(filter) == 1
   assert cuckoo_filter.might_contain(filter, "twice")
 
-  let filter = cuckoo_filter.delete(filter, "twice")
+  let assert Ok(filter) = cuckoo_filter.delete(filter, "twice")
   assert cuckoo_filter.item_count(filter) == 0
   assert !cuckoo_filter.might_contain(filter, "twice")
 }


### PR DESCRIPTION
## What
`cuckoo_filter.delete` now returns `Result(CuckooFilter(a), CuckooFilterError)` instead of `CuckooFilter(a)`. It fails with the new **`ItemNotPresent`** variant when the item's fingerprint is absent from both candidate buckets — i.e. the filter demonstrably does not hold it — instead of silently no-opping.

## Why
A silent no-op on delete hides bugs (double deletes, wrong keys). Surfacing them as an error matches the module's existing `Result`-returning grain.

`ItemNotPresent` joins the unified `CuckooFilterError` type rather than being a bespoke `Nil`/one-off type. The module already commits to a unified per-module error type (every fallible op returns `CuckooFilterError`, e.g. `insert` → `FilterFull`), so a lookup miss belongs there too — it composes in `result.try` chains and stays parallel to `BloomFilterError`.

## What it does *not* do
This is a **misuse check, not a guarantee.** The dangerous case — deleting a never-inserted item whose fingerprint collides with an inserted item's — is fundamentally undetectable: the filter only stores fingerprints, so a collision is indistinguishable from a real hit. That case still returns `Ok` while dropping another item's fingerprint (the false negative these filters otherwise rule out). So:

> `Ok` means "a matching fingerprint was cleared", **not** "you deleted your own item".

The "only delete what you inserted" rule remains necessary. The docstring and README spell this out.

## Changes
- `delete` signature + docstring, new `ItemNotPresent` variant (`src/gauzy/cuckoo_filter.gleam`).
- Tests updated; `delete_missing_item_is_a_no_op_test` → `delete_missing_item_errors_test` (asserts `Error(ItemNotPresent)` + filter untouched).
- README usage example, deletion caveat, and Error Handling section.
- Tidied the `CuckooFilterError` / `BloomFilterError` doc comments.
- **Breaking** → `version` bumped `2.0.4` → `3.0.0`.

Local: `gleam format`, `gleam run -m glinter`, and `gleam test` (17 passed) all clean.